### PR TITLE
Check angular in window before require

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = require('angular')
+module.exports = (window.angular || require('angular'))
   .module('credit-cards', [])
   .value('creditcards', require('creditcards'))
   .directive('ccNumber', require('./number'))


### PR DESCRIPTION
Wouldn't be better to check if angular is exist in window? 
In my environment require('angular') will give me undefined.