### PR TITLE
Move caret to end when formatting number

### DIFF
--- a/src/number.js
+++ b/src/number.js
@@ -46,16 +46,12 @@ function factory ($parse) {
         if ($attributes.ccFormat != null) {
           $scope.$watch($viewValue, function formatInput (input, previous) {
             if (!input) return
-            var element = $element[0]
-            var formatted = card.format(card.parse(input))
-
+            var formatted = card.format(card.parse(input.replace(/\s/g, '')))
             ngModel.$setViewValue(formatted)
-            var selectionEnd = element.selectionEnd
             ngModel.$render()
-            if (formatted && !formatted.charAt(selectionEnd - 1).trim()) {
-              selectionEnd++
-            }
-            element.setSelectionRange(selectionEnd, selectionEnd)
+            var val = $element.val()
+            $element.val('')
+            $element.val(val)
           })
         }
 


### PR DESCRIPTION
This pull request is about `cc-format` directive.

When  move caret by manually and enter, strange phenomenon occurs.
It is as follows:

http://gyazo.com/a2ac84a2b0b2427474759d77c1ccd658

When enter, I suggest moving caret to end of textbox. 
Stripe also is the same behavior.

http://gyazo.com/024476f2cf3596381d3cb36a5a1b27ac