### PR TITLE
Decrements the cursor position when deleted a character after the space

### DIFF
--- a/release/angular-credit-cards.js
+++ b/release/angular-credit-cards.js
@@ -595,7 +595,11 @@ function factory ($parse) {
             var selectionEnd = element.selectionEnd
             ngModel.$render()
             if (formatted && !formatted.charAt(selectionEnd - 1).trim()) {
-              selectionEnd++
+              if (previous && previous.length < input.length) {
+                selectionEnd++
+              } else {
+                selectionEnd--
+              }
             }
             element.setSelectionRange(selectionEnd, selectionEnd)
           })
@@ -616,9 +620,10 @@ function factory ($parse) {
 }
 
 },{"creditcards":12}],17:[function(_dereq_,module,exports){
+(function (global){
 'use strict'
 
-var angular = (window.angular)
+var angular = (typeof window !== "undefined" ? window.angular : typeof global !== "undefined" ? global.angular : null)
 var creditcards = _dereq_('creditcards')
 var number = _dereq_('./number')
 var cvc = _dereq_('./cvc')
@@ -634,5 +639,6 @@ module.exports = angular
   .directive('ccCvc', cvc)
   .name
 
+}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 },{"./cvc":14,"./expiration":15,"./number":16,"creditcards":12}]},{},[17])(17)
 });

--- a/src/number.js
+++ b/src/number.js
@@ -53,7 +53,11 @@ function factory ($parse) {
             var selectionEnd = element.selectionEnd
             ngModel.$render()
             if (formatted && !formatted.charAt(selectionEnd - 1).trim()) {
-              selectionEnd++
+              if (previous && previous.length < input.length) {
+                selectionEnd++
+              } else {
+                selectionEnd--
+              }
             }
             element.setSelectionRange(selectionEnd, selectionEnd)
           })

--- a/test/number.js
+++ b/test/number.js
@@ -70,6 +70,16 @@ describe('cc-number', function () {
       expect(controller.$viewValue).to.equal('4242 4')
       expect(element[0].selectionEnd).to.equal(6)
     })
+
+    it('decrements the cursor when deleted a character after the space', function () {
+      controller.$setViewValue('4242 4')
+      scope.$digest()
+
+      controller.$setViewValue('4242 ')
+      scope.$digest()
+      expect(controller.$viewValue).to.equal('4242')
+      expect(element[0].selectionEnd).to.equal(4)
+    })
   })
 
   describe('ccType (expected type)', function () {


### PR DESCRIPTION
This pullrequest is about `cc-number` and `cc-format`.

E.g. 
When change credit card number `4123 1234 1234 1234`  to `4123 9234 1234 1234`, I pushed `delete` and `9` key.

before
![before](http://i.gyazo.com/241e3bb2ea6a0cbfb990dbc41cc8864d.gif)

after
![after](http://i.gyazo.com/de2ac9523008cfed5c5605258255f37f.gif)
