### PR TITLE
use createTextRange for legacy browser to set cursor position

### DIFF
--- a/src/number.js
+++ b/src/number.js
@@ -29,6 +29,16 @@ function factory ($parse) {
           return ngModel.$viewValue
         }
 
+        function setCursorPostion (element, position) {
+          if (element.setSelectionRange) {
+            element.setSelectionRange(position, position)
+          } else if (element.createTextRange) {
+            var range = element.createTextRange()
+            range.move('character', position)
+            range.select()
+          }
+        }
+
         if ($attributes.ccEagerType != null) {
           $scope.$watch($viewValue, function eagerTypeCheck (number) {
             if (!number) return
@@ -55,7 +65,7 @@ function factory ($parse) {
             if (formatted && !formatted.charAt(selectionEnd - 1).trim()) {
               selectionEnd++
             }
-            element.setSelectionRange(selectionEnd, selectionEnd)
+            setCursorPostion(element, selectionEnd)
           })
         }
 


### PR DESCRIPTION
This pullrequest is about `cc-number` and `cc-format`.

`setSelectionRange` doesn't work for android 4.0.3 default browser.
* http://stackoverflow.com/questions/12009015/setselectionrange-workaround-doesnt-work-for-android-4-0-3
* https://code.google.com/p/android/issues/detail?id=15245

use `createTextRange` instead. inspired by [firstopinion/formatter.js](https://github.com/firstopinion/formatter.js/blob/51c068b/src/inpt-sel.js#L65-L84).