### PR TITLE
Revert bower angular dependency to 1.4.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,9 +28,9 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "~1.4.0"
+    "angular": ">=1.3 <1.5"
   },
   "devDependencies": {
-    "angular-mocks": "~1.4.0"
+    "angular-mocks": ">=1.3 <1.5"
   }
 }


### PR DESCRIPTION
As discussed in https://github.com/bendrucker/angular-credit-cards/issues/49 also released a new version so that angular 1.3.x users can continue to benefit from this good work.