### PR TITLE
Tweak credit card input validation regex

### DIFF
--- a/src/number.js
+++ b/src/number.js
@@ -14,7 +14,7 @@ function factory ($parse) {
       this.eagerType = null
     },
     compile: function ($element, $attributes) {
-      $attributes.$set('pattern', '[0-9]*')
+      $attributes.$set('pattern', '^(\\d*|(\\d+)( \\d+)+)$')
       $attributes.$set('xAutocompletetype', 'cc-number')
 
       return function ($scope, $element, $attributes, controllers) {


### PR DESCRIPTION
This PR modifies the regexp in the pattern attribute for the credit card input type slightly. It will now match either the empty string, a series of digits with no embedded whitespace, or series of digits separated by whitespace (but no leading or trailing whitespace).

The reason for this edit is because the pretty formatted credit card number (which we want to use) causes the browser to treat the value as invalid. (Screen shot attached below.)

This PR fixes #61.

![Screen shot of Invalid input notice](https://dl.dropboxusercontent.com/u/8182518/foorumikuvat/Screen%20Shot%202015-07-30%20at%209.14.55%20PM.png)