### PR TITLE
fix invalid input element when use cc-number with cc-format

### DIFF
--- a/src/number.js
+++ b/src/number.js
@@ -14,7 +14,7 @@ function factory ($parse) {
       this.eagerType = null
     },
     compile: function ($element, $attributes) {
-      $attributes.$set('pattern', '[0-9]*')
+      $attributes.$set('pattern', $attributes.ccFormat == null ? '[0-9]*' : '[0-9 ]*')
       $attributes.$set('xAutocompletetype', 'cc-number')
 
       return function ($scope, $element, $attributes, controllers) {

--- a/test/number.js
+++ b/test/number.js
@@ -19,7 +19,7 @@ describe('cc-number', function () {
   }))
 
   it('adds a numeric pattern', function () {
-    expect(element.attr('pattern')).to.equal('[0-9]*')
+    expect(element.attr('pattern')).to.equal('[0-9]* ')
   })
 
   it('adds an autocomplete attribute', function () {


### PR DESCRIPTION
When use cc-number with cc-format, 'input' element is invalid even if it's a correct number because of its pattern([0-9]*).
I added space in the rex when cc-format is on.