### PR TITLE
Let Number values pass validation if input type is `number`

### DIFF
--- a/src/cvc.js
+++ b/src/cvc.js
@@ -17,7 +17,10 @@ function factory ($parse) {
 
       return function (scope, element, attributes, ngModel) {
         ngModel.$validators.ccCvc = function (value) {
-          return cvc.isValid(value, $parse(attributes.ccType)(scope))
+          return cvc.isValid(
+            attributes.type === 'number' ? value + '' : value,
+            $parse(attributes.ccType)(scope)
+          )
         }
 
         if (attributes.ccType) {

--- a/test/cvc.js
+++ b/test/cvc.js
@@ -44,10 +44,20 @@ describe('cc-cvc', function () {
     expect(scope.card.cvc).to.equal('1234')
   })
 
-  it('does not accept numbers', function () {
+  it('does not accept numbers if input has type other than "number"',
+    function () {
     controller.$setViewValue(123)
     scope.$digest()
     expect(controller.$valid).to.be.false
+  })
+
+  it('accepts numbers if input has type of "number"', function () {
+    element =
+      angular.element('<input type="number" ng-model="card.cvc" cc-cvc />')
+    controller = $compile(element)(scope).controller('ngModel')
+    controller.$setViewValue(123)
+    scope.$digest()
+    expect(controller.$valid).to.be.true
   })
 
   it('unsets the model value when invalid', function () {


### PR DESCRIPTION
This allows cvc field to be a number which makes mobile devices show numerical
keyboard in this field.

It resolves a problem described in [bendrucker/creditcards#8](https://github.com/bendrucker/creditcards/issues/8)