### PR TITLE
Allow specifying array of allowed credit card types

### DIFF
--- a/src/number.js
+++ b/src/number.js
@@ -83,7 +83,15 @@ function factory ($parse) {
         }
 
         ngModel.$validators.ccNumberType = function validateCcNumberType (number) {
-          return card.isValid(number, $parse($attributes.ccType)($scope))
+          var cardTypes = $parse($attributes.ccType)($scope)
+          if (!angular.isArray(cardTypes)) {
+            cardTypes = [cardTypes]
+          }
+          var result = false
+          angular.forEach(cardTypes, function(value) {
+            result = result || card.isValid(number, value);
+          })
+          return result
         }
       }
     }

--- a/src/number.js
+++ b/src/number.js
@@ -84,12 +84,12 @@ function factory ($parse) {
 
         ngModel.$validators.ccNumberType = function validateCcNumberType (number) {
           var cardTypes = $parse($attributes.ccType)($scope)
-          if (!angular.isArray(cardTypes)) {
+          if (!(cardTypes instanceof Array)) {
             cardTypes = [cardTypes]
           }
           var result = false
-          angular.forEach(cardTypes, function(value) {
-            result = result || card.isValid(number, value);
+          cardTypes.forEach(function (value) {
+            result = result || card.isValid(number, value)
           })
           return result
         }


### PR DESCRIPTION
Allow using an array for the allowed credit card types, such as:

```html
<input 
    type="text" 
    ng-model="card.number"
    cc-number
    cc-type="['Visa', 'MasterCard']" />
```

Extremely useful for us Europeans that cannot accept all credit card types through Stripe.