### PR TITLE
fix for cursor position with some cards

### DIFF
--- a/src/number.js
+++ b/src/number.js
@@ -65,12 +65,9 @@ function factory ($parse) {
             var selectionEnd = element.selectionEnd
             ngModel.$setViewValue(formatted)
             ngModel.$render()
-            if (formatted && (!formatted.charAt(selectionEnd - 1).trim())) {
-              if (previous && previous.length < formatted.length) {
-                selectionEnd++
-              } else {
-                selectionEnd--
-              }
+            
+            if (previous && previous.length < formatted.length) {
+              selectionEnd = formatted.length
             }
             setCursorPostion(element, selectionEnd)
 


### PR DESCRIPTION
Cards where formatting occurs while the last digit is a `0` resulted in an improper cursor position.

I tried a variety of test cards and don't see anything that requires all of the logic that is in the current condition. The initial bug was related to `!formatted.charAt(selectionEnd - 1).trim()` can return falsey for `"0"`.

Testing:
* type in the CC number `6011000990139424` expected formatting `6011 0009 9013 9424`
* this exposes two formatting bugs, one that occurs when the third 0 is typed in, and another after the second space
* here is the demo plunk with `cc-format` added on http://plnkr.co/edit/nEUPFRbFDZHWvhHdePA1?p=preview

closes #111 
closes #79
closes #83