### PR TITLE
Avoid angular being pulled in by browserifying tools

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,11 @@
 'use strict'
 
-var angular = require('angular')
 var creditcards = require('creditcards')
 var number = require('./number')
 var cvc = require('./cvc')
 var expiration = require('./expiration')
 
-module.exports = angular
+module.exports = angular // eslint-disable-line no-undef
   .module('credit-cards', [])
   .value('creditcards', creditcards)
   .directive('ccNumber', number)


### PR DESCRIPTION
Assume for a second that we have an angular component that makes use of angular-credit-cards:

```javascript
import creditCards from "angular-credit-cards";

angular.module("mypayments", [ creditCards ])
    .component('myCreditCardForm', {
    	...
    });
```

If I then pump my source through browserify the resulting bundle will include the angular source itself. This is because despite angular being defined as a peer dependency in angular-credit-cards it is "required" explicitly in `index.js`. There should be no need for this require given that whatever web application is hosting the component will need to provide angular anyway.

This PR simply removes that explicit "require".

Of course, one solution is to simply tell browserify to exclude angular from the bundle. However, I don't actually want to do any browserifying on my component at all - I want to delegate the browserifying to the web app that is hosting my component. This is to avoid any transitive dependencies of my component (or angular-credit-cards) being bundled and clashing with dependencies of the web app itself.

Seem reasonable?