### PR TITLE
Do not overwrite global angular variable. Fixes #167

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,9 @@
   "standard": {
     "ignore": [
       "release/"
+    ],
+    "globals": [
+      "angular"
     ]
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var angular = require('angular')
+require('angular')
 var creditcards = require('creditcards')
 var number = require('./number')
 var cvc = require('./cvc')


### PR DESCRIPTION
Two changes were required to fix #167 

1. Do not declare global `angular` variable in src/index.js.
2. Add `globals` configuration for standardjs.

All tests pass. 👍 💯 