### PR TITLE
IE11 fix for regression in 3.1.7

### DIFF
--- a/src/number.js
+++ b/src/number.js
@@ -60,7 +60,6 @@ function factory ($parse, $timeout) {
           ngModel.$formatters.unshift(card.format)
           $element.on('input', function formatInput () {
             var input = $element.val()
-            var previous = $viewValue()
             if (!input) return
             var element = $element[0]
             var formatted = card.format(card.parse(input))
@@ -69,7 +68,7 @@ function factory ($parse, $timeout) {
             ngModel.$setViewValue(formatted)
             ngModel.$render()
 
-            if (previous && selectionEnd === previous.length && previous.length < formatted.length) {
+            if (selectionEnd === input.length && input.length < formatted.length) {
               selectionEnd = formatted.length
             }
             setCursorPostion(element, selectionEnd)


### PR DESCRIPTION
This addresses the issue outlined in #169.
After debugging this for a while, it seems as if you could just use the value from the input instead of the $viewValue. IE doesn't update the $viewValue like the other browsers. Tested in IE11, Chrome and Firefox.

Unfortunately, I am unable to run the tests for this project. Running `npm install` results in an error relating to a path issue installing zuul. I'll try to use my Mac to run the tests instead of Windows 10.