### PR TITLE
Add support for Angular 1.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Tests
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '12.x'
+    - run: npm install
+    - run: npm test

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "function-bind": "~1.1.0"
   },
   "peerDependencies": {
-    "angular": ">=1.3 <1.8"
+    "angular": ">=1.3 <2"
   },
   "files": [
     "src/*.js",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "function-bind": "~1.1.0"
   },
   "peerDependencies": {
-    "angular": ">=1.3 <1.7"
+    "angular": ">=1.3 <1.8"
   },
   "files": [
     "src/*.js",


### PR DESCRIPTION
AngularJS 1.8 is a final series of security patches:

https://github.com/angular/angular.js/blob/master/CHANGELOG.md#180-nested-vaccination-2020-06-01

While I have no plans to make this library compatible with the current release of Angular, it should be 1.8-compatible.

Closes #179